### PR TITLE
Feat: FastAPI backend layer (closes #6)

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI backend for Dual Photography."""

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,0 +1,238 @@
+"""FastAPI backend for Dual Photography.
+
+Provides REST API endpoints for:
+    - Scene simulation and transport matrix computation
+    - Dual image generation via Helmholtz reciprocity (T^T)
+    - Virtual relighting with arbitrary projector patterns
+    - SVD analysis of the transport matrix
+    - Scene listing and health checks
+
+The API wraps the core DualPhotographer pipeline, making it accessible
+to web frontends and external tools without requiring direct Python imports.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from src.core.dual import DualPhotographer
+from src.core.transport import TransportMatrix
+from src.simulation.scene import SceneType, SyntheticScene
+
+
+# -- Pydantic request/response models --
+
+class SimulateRequest(BaseModel):
+    """Request body for /api/simulate."""
+    scene_type: str = Field("cornell_box", description="Scene type identifier")
+    resolution: int = Field(32, ge=4, le=128, description="Grid resolution (NxN)")
+    n_bounces: int = Field(0, ge=0, le=3, description="Number of indirect light bounces")
+
+
+class RelightRequest(BaseModel):
+    """Request body for /api/relight."""
+    pattern_type: str = Field(
+        "horizontal_gradient",
+        description="Pattern name: horizontal_gradient, vertical_gradient, spot, uniform, checkerboard",
+    )
+
+
+class SvdRequest(BaseModel):
+    """Request body for /api/svd."""
+    rank: int = Field(10, ge=1, le=512, description="Number of singular values to retain")
+
+
+# -- Application state --
+
+class AppState:
+    """Holds the current simulation state between requests."""
+
+    def __init__(self):
+        self.photographer: Optional[DualPhotographer] = None
+        self.scene: Optional[SyntheticScene] = None
+        self.resolution: int = 32
+
+
+state = AppState()
+
+
+# -- FastAPI app --
+
+app = FastAPI(
+    title="Dual Photography API",
+    description=(
+        "REST API for simulating light transport, generating dual images "
+        "via Helmholtz reciprocity, and performing virtual relighting."
+    ),
+    version="2.0.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# -- Helper functions --
+
+def _scene_type_from_str(name: str) -> SceneType:
+    """Convert a string scene name to SceneType enum."""
+    name_lower = name.lower().replace(" ", "_")
+    for st in SceneType:
+        if st.value == name_lower:
+            return st
+    raise ValueError(f"Unknown scene type: {name}. Available: {[s.value for s in SceneType]}")
+
+
+def _generate_pattern(pattern_type: str, shape: tuple[int, int]) -> np.ndarray:
+    """Generate a named relighting pattern."""
+    h, w = shape
+    if pattern_type == "horizontal_gradient":
+        return np.tile(np.linspace(0, 1, w), (h, 1))
+    elif pattern_type == "vertical_gradient":
+        return np.tile(np.linspace(0, 1, h).reshape(-1, 1), (1, w))
+    elif pattern_type == "spot":
+        y, x = np.ogrid[:h, :w]
+        cy, cx = h / 2, w / 2
+        r = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
+        return np.clip(1.0 - r / max(cy, cx), 0, 1)
+    elif pattern_type == "uniform":
+        return np.ones((h, w))
+    elif pattern_type == "checkerboard":
+        pattern = np.zeros((h, w))
+        pattern[::2, ::2] = 1
+        pattern[1::2, 1::2] = 1
+        return pattern
+    else:
+        raise ValueError(
+            f"Unknown pattern: {pattern_type}. "
+            "Available: horizontal_gradient, vertical_gradient, spot, uniform, checkerboard"
+        )
+
+
+# -- Endpoints --
+
+@app.get("/api/health")
+async def health():
+    """Health check endpoint."""
+    return {"status": "ok", "version": "2.0.0"}
+
+
+@app.get("/api/scenes")
+async def list_scenes():
+    """List all available scene types."""
+    return {"scenes": [st.value for st in SceneType]}
+
+
+@app.post("/api/simulate")
+async def simulate(req: SimulateRequest):
+    """Run a full dual photography simulation.
+
+    Builds a synthetic scene, computes the light transport matrix T,
+    and generates both camera and dual images.
+    """
+    try:
+        scene_type = _scene_type_from_str(req.scene_type)
+    except ValueError as e:
+        raise HTTPException(400, detail=str(e))
+
+    try:
+        res = req.resolution
+        scene = SyntheticScene(
+            scene_type=scene_type,
+            proj_shape=(res, res),
+            cam_shape=(res, res),
+            n_bounces=req.n_bounces,
+        )
+        T = scene.compute_transport_matrix()
+
+        photographer = DualPhotographer(
+            proj_shape=(res, res),
+            cam_shape=(res, res),
+        )
+        photographer.compute_transport_from_simulation(T)
+
+        # Store in state for subsequent relight/svd calls
+        state.photographer = photographer
+        state.scene = scene
+        state.resolution = res
+
+        # Generate default images
+        camera_image = photographer.transport.forward(np.ones((res, res)))
+        dual_image = photographer.dual_image()
+
+        return {
+            "scene_type": scene_type.value,
+            "resolution": res,
+            "transport_shape": list(T.shape),
+            "camera_image": camera_image.tolist(),
+            "dual_image": dual_image.tolist(),
+            "transport_norm": float(np.linalg.norm(T)),
+            "transport_sparsity": photographer.transport.sparsity(),
+        }
+    except Exception as e:
+        raise HTTPException(500, detail=str(e))
+
+
+@app.post("/api/relight")
+async def relight(req: RelightRequest):
+    """Apply virtual relighting with a new projector pattern."""
+    if state.photographer is None:
+        raise HTTPException(400, detail="No simulation loaded. Call /api/simulate first.")
+
+    try:
+        pattern = _generate_pattern(req.pattern_type, state.photographer.proj_shape)
+        relighted = state.photographer.relight(pattern)
+        return {
+            "pattern_type": req.pattern_type,
+            "relighted_image": relighted.tolist(),
+            "pattern": pattern.tolist(),
+        }
+    except ValueError as e:
+        raise HTTPException(400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(500, detail=str(e))
+
+
+@app.get("/api/svd")
+async def svd_analysis(rank: int = 10):
+    """Get SVD decomposition analysis of the transport matrix."""
+    if state.photographer is None:
+        raise HTTPException(400, detail="No simulation loaded. Call /api/simulate first.")
+
+    try:
+        analysis = state.photographer.analyze_transport(rank=rank)
+        return {
+            "rank": rank,
+            "singular_values": analysis["singular_values"][:rank].tolist(),
+            "condition_number": float(analysis["condition_number"]),
+            "energy_cumulative": analysis["energy_cumulative"][:rank].tolist(),
+            "effective_rank_90": int(analysis["effective_rank_90"]),
+            "effective_rank_99": int(analysis["effective_rank_99"]),
+        }
+    except Exception as e:
+        raise HTTPException(500, detail=str(e))
+
+
+@app.get("/api/frequency")
+async def frequency_analysis():
+    """Get 2D Fourier frequency analysis of the transport matrix."""
+    if state.photographer is None:
+        raise HTTPException(400, detail="No simulation loaded. Call /api/simulate first.")
+
+    try:
+        freq = state.photographer.transport.frequency_analysis()
+        return {
+            "dc_fraction": freq["dc_fraction"],
+            "high_freq_fraction": freq["high_freq_fraction"],
+            "radial_profile": freq["radial_profile"].tolist(),
+        }
+    except Exception as e:
+        raise HTTPException(500, detail=str(e))

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -32,6 +32,14 @@ class SimulateRequest(BaseModel):
     scene_type: str = Field("cornell_box", description="Scene type identifier")
     resolution: int = Field(32, ge=4, le=128, description="Grid resolution (NxN)")
     n_bounces: int = Field(0, ge=0, le=3, description="Number of indirect light bounces")
+    compression_ratio: Optional[float] = Field(
+        None, ge=0.05, le=1.0,
+        description=(
+            "If set, use compressed sensing with M = ratio * N random patterns "
+            "instead of full canonical acquisition. Reduces acquisition time at "
+            "the cost of reconstruction accuracy (Peers et al., 2009)."
+        ),
+    )
 
 
 class RelightRequest(BaseModel):
@@ -157,7 +165,19 @@ async def simulate(req: SimulateRequest):
             proj_shape=(res, res),
             cam_shape=(res, res),
         )
-        photographer.compute_transport_from_simulation(T)
+
+        if req.compression_ratio is not None:
+            n_proj = res * res
+            n_patterns = max(1, int(req.compression_ratio * n_proj))
+            tm = TransportMatrix.from_compressed_sensing(
+                scene_transport=T,
+                n_patterns=n_patterns,
+                proj_shape=(res, res),
+                cam_shape=(res, res),
+            )
+            photographer.transport = tm
+        else:
+            photographer.compute_transport_from_simulation(T)
 
         # Store in state for subsequent relight/svd calls
         state.photographer = photographer

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -221,6 +221,41 @@ async def svd_analysis(rank: int = 10):
         raise HTTPException(500, detail=str(e))
 
 
+@app.get("/api/transport")
+async def get_transport(mode: str = "svd", rank: int = 10):
+    """Get transport matrix in compact or full form.
+
+    Args:
+        mode: 'svd' returns truncated factors (U, S, Vt). 'full' returns dense matrix.
+        rank: Number of singular values for SVD mode.
+    """
+    if state.photographer is None:
+        raise HTTPException(400, detail="No simulation loaded. Call /api/simulate first.")
+
+    try:
+        T = state.photographer.transport.T
+
+        if mode == 'svd':
+            U, s, Vt = np.linalg.svd(T, full_matrices=False)
+            k = min(rank, len(s))
+            return {
+                "mode": "svd",
+                "rank": k,
+                "U": U[:, :k].tolist(),
+                "S": s[:k].tolist(),
+                "Vt": Vt[:k, :].tolist(),
+                "shape": list(T.shape),
+            }
+        else:
+            return {
+                "mode": "full",
+                "matrix": T.tolist(),
+                "shape": list(T.shape),
+            }
+    except Exception as e:
+        raise HTTPException(500, detail=str(e))
+
+
 @app.get("/api/frequency")
 async def frequency_analysis():
     """Get 2D Fourier frequency analysis of the transport matrix."""

--- a/src/core/transport.py
+++ b/src/core/transport.py
@@ -315,6 +315,58 @@ class TransportMatrix:
             "density_per_column": nnz / self.T.shape[1],
         }
 
+    @classmethod
+    def from_compressed_sensing(
+        cls,
+        scene_transport: np.ndarray,
+        n_patterns: int,
+        proj_shape: tuple[int, int],
+        cam_shape: tuple[int, int],
+        seed: int | None = 42,
+    ) -> TransportMatrix:
+        """Compressive light transport with random patterns.
+
+        Instead of N structured patterns (one per pixel), uses M << N
+        random patterns and reconstructs T via least-squares.
+
+        This reduces acquisition time by factor N/M while preserving
+        most of the transport matrix information (Peers et al., 2009).
+
+        Args:
+            scene_transport: The true transport matrix (cam_pixels, proj_pixels),
+                used here to simulate scene responses to random patterns.
+            n_patterns: Number of random patterns M (typically 0.3*N).
+            proj_shape: Projector resolution as (height, width).
+            cam_shape: Camera resolution as (height, width).
+            seed: Random seed for reproducibility.
+
+        Returns:
+            TransportMatrix with the approximate T reconstructed from
+            compressed measurements.
+        """
+        n_cam = cam_shape[0] * cam_shape[1]
+        n_proj = proj_shape[0] * proj_shape[1]
+        M = min(n_patterns, n_proj)
+
+        rng = np.random.default_rng(seed)
+
+        # Generate random measurement patterns (M random patterns of length N)
+        patterns = rng.standard_normal((M, n_proj))
+
+        # Simulate responses: each response = T @ pattern_i
+        # responses[:, i] = T @ patterns[i]
+        responses = scene_transport @ patterns.T  # (n_cam, M)
+
+        # Reconstruct T via least-squares: responses = T_approx @ patterns.T
+        # T_approx = responses @ pinv(patterns.T)
+        T_approx = responses @ np.linalg.pinv(patterns.T)
+
+        return cls(
+            T=T_approx,
+            cam_shape=cam_shape,
+            proj_shape=proj_shape,
+        )
+
     def reciprocity_error(self) -> float:
         """Measure deviation from Helmholtz reciprocity (T vs T^T).
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,131 @@
+"""Tests for the FastAPI backend endpoints.
+
+Validates health, scene listing, simulation, relighting, and SVD endpoints.
+"""
+
+import numpy as np
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+
+from src.api.main import app, state
+
+
+@pytest.fixture
+def transport():
+    return ASGITransport(app=app)
+
+
+@pytest_asyncio.fixture
+async def client(transport):
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint(client):
+    """GET /api/health should return status ok."""
+    response = await client.get("/api/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["version"] == "2.0.0"
+
+
+@pytest.mark.asyncio
+async def test_list_scenes(client):
+    """GET /api/scenes should return available scene types."""
+    response = await client.get("/api/scenes")
+    assert response.status_code == 200
+    data = response.json()
+    assert "scenes" in data
+    assert "cornell_box" in data["scenes"]
+    assert len(data["scenes"]) >= 5
+
+
+@pytest.mark.asyncio
+async def test_simulate_creates_transport(client):
+    """POST /api/simulate should compute transport matrix and return images."""
+    response = await client.post(
+        "/api/simulate",
+        json={"scene_type": "flat_textured", "resolution": 8, "n_bounces": 0},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["resolution"] == 8
+    assert data["transport_shape"] == [64, 64]
+    assert "camera_image" in data
+    assert "dual_image" in data
+    assert data["transport_norm"] > 0
+
+
+@pytest.mark.asyncio
+async def test_simulate_invalid_scene(client):
+    """POST /api/simulate with invalid scene should return 400."""
+    response = await client.post(
+        "/api/simulate",
+        json={"scene_type": "nonexistent_scene", "resolution": 8},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_relight_after_simulate(client):
+    """POST /api/relight should work after simulation."""
+    # First simulate
+    await client.post(
+        "/api/simulate",
+        json={"scene_type": "flat_textured", "resolution": 8, "n_bounces": 0},
+    )
+    # Then relight
+    response = await client.post(
+        "/api/relight",
+        json={"pattern_type": "horizontal_gradient"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pattern_type"] == "horizontal_gradient"
+    assert "relighted_image" in data
+
+
+@pytest.mark.asyncio
+async def test_relight_without_simulate(client):
+    """POST /api/relight before simulate should return 400."""
+    # Reset state
+    state.photographer = None
+    response = await client.post(
+        "/api/relight",
+        json={"pattern_type": "spot"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_svd_analysis(client):
+    """GET /api/svd should return singular value decomposition."""
+    # First simulate
+    await client.post(
+        "/api/simulate",
+        json={"scene_type": "flat_textured", "resolution": 8, "n_bounces": 0},
+    )
+    response = await client.get("/api/svd", params={"rank": 5})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["rank"] == 5
+    assert len(data["singular_values"]) == 5
+    assert data["effective_rank_90"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_relight_all_patterns(client):
+    """All built-in pattern types should produce valid relighting results."""
+    await client.post(
+        "/api/simulate",
+        json={"scene_type": "flat_textured", "resolution": 8, "n_bounces": 0},
+    )
+    for pattern in ["horizontal_gradient", "vertical_gradient", "spot", "uniform", "checkerboard"]:
+        response = await client.post(
+            "/api/relight",
+            json={"pattern_type": pattern},
+        )
+        assert response.status_code == 200, f"Pattern '{pattern}' failed"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -117,6 +117,47 @@ async def test_svd_analysis(client):
 
 
 @pytest.mark.asyncio
+async def test_transport_svd_mode(client):
+    """GET /api/transport?mode=svd should return truncated SVD factors."""
+    await client.post(
+        "/api/simulate",
+        json={"scene_type": "flat_textured", "resolution": 8, "n_bounces": 0},
+    )
+    response = await client.get("/api/transport", params={"mode": "svd", "rank": 5})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "svd"
+    assert data["rank"] == 5
+    assert len(data["S"]) == 5
+    assert len(data["U"]) > 0
+    assert len(data["Vt"]) == 5
+    assert data["shape"] == [64, 64]
+
+
+@pytest.mark.asyncio
+async def test_transport_full_mode(client):
+    """GET /api/transport?mode=full should return the full matrix."""
+    await client.post(
+        "/api/simulate",
+        json={"scene_type": "flat_textured", "resolution": 8, "n_bounces": 0},
+    )
+    response = await client.get("/api/transport", params={"mode": "full"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "full"
+    assert data["shape"] == [64, 64]
+    assert len(data["matrix"]) == 64
+
+
+@pytest.mark.asyncio
+async def test_transport_without_simulate(client):
+    """GET /api/transport before simulate should return 400."""
+    state.photographer = None
+    response = await client.get("/api/transport")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_relight_all_patterns(client):
     """All built-in pattern types should produce valid relighting results."""
     await client.post(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -193,3 +193,62 @@ class TestDualPhotographer:
         photographer = DualPhotographer(proj_shape=(4, 4), cam_shape=(4, 4))
         with pytest.raises(RuntimeError, match="Transport matrix not computed"):
             photographer.dual_image()
+
+
+class TestCompressedSensing:
+    """Tests for compressive light transport acquisition."""
+
+    def test_compressed_reconstruction_shape(self):
+        """Compressed sensing produces correct matrix shape."""
+        rng = np.random.default_rng(42)
+        T_true = rng.random((16, 16))
+        tm = TransportMatrix.from_compressed_sensing(
+            scene_transport=T_true,
+            n_patterns=16,  # full measurement
+            proj_shape=(4, 4),
+            cam_shape=(4, 4),
+        )
+        assert tm.T.shape == (16, 16)
+
+    def test_full_measurement_recovers_T(self):
+        """With M=N patterns, compressed sensing should recover T exactly."""
+        rng = np.random.default_rng(42)
+        T_true = rng.random((16, 16))
+        tm = TransportMatrix.from_compressed_sensing(
+            scene_transport=T_true,
+            n_patterns=16,
+            proj_shape=(4, 4),
+            cam_shape=(4, 4),
+        )
+        np.testing.assert_allclose(tm.T, T_true, atol=1e-8)
+
+    def test_compressed_forward(self):
+        """Forward pass with compressed T produces valid output."""
+        rng = np.random.default_rng(42)
+        T_true = rng.random((16, 16))
+        tm = TransportMatrix.from_compressed_sensing(
+            scene_transport=T_true,
+            n_patterns=8,  # 50% compression
+            proj_shape=(4, 4),
+            cam_shape=(4, 4),
+        )
+        pattern = np.ones((4, 4))
+        result = tm.forward(pattern)
+        assert result.shape == (4, 4)
+
+    def test_compression_ratio_tradeoff(self):
+        """More patterns should give a better approximation."""
+        rng = np.random.default_rng(42)
+        T_true = rng.random((16, 16))
+        tm_low = TransportMatrix.from_compressed_sensing(
+            scene_transport=T_true, n_patterns=4,
+            proj_shape=(4, 4), cam_shape=(4, 4), seed=42,
+        )
+        tm_high = TransportMatrix.from_compressed_sensing(
+            scene_transport=T_true, n_patterns=12,
+            proj_shape=(4, 4), cam_shape=(4, 4), seed=42,
+        )
+        err_low = np.linalg.norm(tm_low.T - T_true)
+        err_high = np.linalg.norm(tm_high.T - T_true)
+        assert err_high <= err_low, \
+            f"More patterns should reduce error: {err_high:.4f} > {err_low:.4f}"


### PR DESCRIPTION
## Summary
- New `src/api/main.py` with 6 REST endpoints: health, scenes, simulate, relight, SVD, frequency
- Decouples computation from Dash frontend
- Full Pydantic request/response models
- 8 async API tests with httpx
- Resolves #6

## Test plan
- [ ] `python -m pytest tests/ -v`

---
@codex The backend exposes the transport matrix via REST. But the matrix T is NxN where N = resolution². For res=64, that's 4096×4096 = 16M floats. Should the API stream it, compress it, or just return the SVD components instead? What would you do? 📡

_@codex Le backend expose la matrice de transport via REST. Mais T est N×N où N=résolution². Pour res=64, c'est 16M de flottants. L'API devrait-elle streamer, compresser, ou juste renvoyer les composants SVD ? Qu'est-ce que tu ferais ?_ 🇫🇷

🤖 Generated with [Claude Code](https://claude.ai/claude-code)