### PR TITLE
Feat: Spectral transport + calibration (closes #13)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 from src.core.dual import DualPhotographer
 from src.core.transport import TransportMatrix
 from src.core.calibration import generate_gray_code_patterns, decode_gray_code, build_correspondence_map
+from src.core.spectral import SpectralTransportMatrix, simulate_rgb_transport
 from src.simulation.scene import SceneType, SyntheticScene
 
 
@@ -81,6 +82,21 @@ class CalibrateRequest(BaseModel):
     noise_level: float = Field(0.0, ge=0.0, le=1.0, description="Simulated capture noise (0-1)")
 
 
+class SpectralSimulateRequest(BaseModel):
+    """Request body for /api/spectral-simulate."""
+    resolution: int = Field(8, ge=4, le=64, description="Grid resolution (NxN)")
+    seed: int = Field(42, description="Random seed for reproducibility")
+
+
+class SpectralRelightRequest(BaseModel):
+    """Request body for /api/spectral-relight."""
+    channel: str = Field("red", description="Wavelength channel: red, green, blue")
+    pattern_type: str = Field(
+        "uniform",
+        description="Virtual illumination pattern: uniform, spot, horizontal_gradient",
+    )
+
+
 # -- Application state --
 
 class AppState:
@@ -90,6 +106,7 @@ class AppState:
         self.photographer: Optional[DualPhotographer] = None
         self.scene: Optional[SyntheticScene] = None
         self.resolution: int = 32
+        self.spectral: Optional[SpectralTransportMatrix] = None
 
 
 state = AppState()
@@ -339,6 +356,71 @@ async def frequency_analysis():
             "radial_profile": freq["radial_profile"].tolist(),
         }
     except Exception as e:
+        raise HTTPException(500, detail=str(e))
+
+
+@app.post("/api/spectral-simulate")
+async def spectral_simulate(req: SpectralSimulateRequest):
+    """Simulate spectral (RGB) transport matrices.
+
+    Creates wavelength-dependent transport matrices that capture how
+    different wavelengths of light propagate through the scene.
+    """
+    _log(f"Spectral simulate: res={req.resolution}, seed={req.seed}")
+    try:
+        spectral = simulate_rgb_transport(resolution=req.resolution, seed=req.seed)
+        state.spectral = spectral
+
+        # Generate a sample forward image per channel with uniform illumination
+        n = req.resolution * req.resolution
+        uniform = np.ones(n)
+        sample_images = {}
+        for name, T in spectral.channels.items():
+            img = T @ uniform
+            sample_images[name] = np.clip(img, 0, None).tolist()
+
+        _log(f"Spectral simulate complete: {len(spectral.channels)} channels")
+        return {
+            **spectral.get_state(),
+            "sample_images": sample_images,
+        }
+    except Exception as e:
+        _log(f"Spectral simulate failed: {e}")
+        raise HTTPException(500, detail=str(e))
+
+
+@app.post("/api/spectral-relight")
+async def spectral_relight(req: SpectralRelightRequest):
+    """Compute a spectral dual image (view from projector) for one channel.
+
+    Requires a prior call to /api/spectral-simulate.
+    """
+    if state.spectral is None:
+        _log("Spectral relight failed: no spectral simulation loaded")
+        raise HTTPException(400, detail="No spectral simulation. Call /api/spectral-simulate first.")
+
+    _log(f"Spectral relight: channel={req.channel}, pattern={req.pattern_type}")
+    try:
+        res = state.spectral.resolution
+        n = res * res
+        shape = (res, res)
+        pattern = _generate_pattern(req.pattern_type, shape).flatten()
+
+        dual_img = state.spectral.dual_image_spectral(req.channel, pattern)
+        dual_img = np.clip(dual_img, 0, None)
+
+        _log(f"Spectral relight complete: channel={req.channel}")
+        return {
+            "channel": req.channel,
+            "pattern_type": req.pattern_type,
+            "dual_image": dual_img.tolist(),
+            "resolution": res,
+        }
+    except ValueError as e:
+        _log(f"Spectral relight error: {e}")
+        raise HTTPException(400, detail=str(e))
+    except Exception as e:
+        _log(f"Spectral relight failed: {e}")
         raise HTTPException(500, detail=str(e))
 
 

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,4 +1,4 @@
-"""Core engine for dual photography: transport matrix, SVD, BRDF, calibration, and dual image computation."""
+"""Core engine for dual photography: transport matrix, SVD, BRDF, calibration, spectral, and dual image computation."""
 
 from src.core.transport import TransportMatrix
 from src.core.dual import DualPhotographer
@@ -8,6 +8,7 @@ from src.core.calibration import (
     decode_gray_code,
     build_correspondence_map,
 )
+from src.core.spectral import SpectralTransportMatrix, simulate_rgb_transport
 
 __all__ = [
     "TransportMatrix",
@@ -17,4 +18,6 @@ __all__ = [
     "generate_gray_code_patterns",
     "decode_gray_code",
     "build_correspondence_map",
+    "SpectralTransportMatrix",
+    "simulate_rgb_transport",
 ]

--- a/src/core/spectral.py
+++ b/src/core/spectral.py
@@ -1,0 +1,105 @@
+"""
+Spectral transport matrix for wavelength-dependent dual photography.
+
+Computes transport matrices at multiple wavelengths, enabling:
+- Spectral relighting (change illumination color)
+- Material classification (different materials reflect differently per wavelength)
+- Chromatic dual photography (color-accurate projector-view reconstruction)
+
+The spectral transport is a set of N transport matrices T_lambda, one per
+wavelength channel. Each T_lambda captures how light at wavelength lambda
+propagates from projector to camera through the scene.
+
+For RGB simplification: T_R, T_G, T_B (3 transport matrices).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Dict, Optional
+
+
+class SpectralTransportMatrix:
+    """Wavelength-dependent transport matrix collection."""
+
+    def __init__(self, resolution: int = 32):
+        self.resolution = resolution
+        self.channels: Dict[str, np.ndarray] = {}  # name -> T matrix
+
+    def add_channel(self, name: str, transport_matrix: np.ndarray):
+        """Add a transport matrix for a wavelength channel."""
+        self.channels[name] = transport_matrix.copy()
+
+    def compute_rgb_from_scene(self, scene_reflectance_rgb: Dict[str, np.ndarray],
+                                projector_pattern: np.ndarray) -> Dict[str, np.ndarray]:
+        """Compute camera image for each color channel.
+
+        Args:
+            scene_reflectance_rgb: Dict mapping channel name to reflectance.
+            projector_pattern: 1D illumination pattern.
+
+        Returns:
+            Dict mapping channel name to camera image (1D).
+        """
+        result = {}
+        for name, T in self.channels.items():
+            if name in scene_reflectance_rgb:
+                # Element-wise multiply T by reflectance, then project
+                T_weighted = T * scene_reflectance_rgb[name][np.newaxis, :]
+                result[name] = T_weighted @ projector_pattern
+            else:
+                result[name] = T @ projector_pattern
+        return result
+
+    def dual_image_spectral(self, channel: str, virtual_illumination: np.ndarray) -> np.ndarray:
+        """Compute spectral dual image for a single channel.
+
+        Dual image: I_dual = T^T @ virtual_illumination
+        """
+        if channel not in self.channels:
+            raise ValueError(f"Unknown channel: {channel}")
+        return self.channels[channel].T @ virtual_illumination
+
+    def get_state(self) -> dict:
+        """Serialize for API response."""
+        return {
+            'resolution': self.resolution,
+            'channels': list(self.channels.keys()),
+            'shapes': {name: list(T.shape) for name, T in self.channels.items()},
+        }
+
+
+def simulate_rgb_transport(resolution: int = 32,
+                            seed: int = 42) -> SpectralTransportMatrix:
+    """Simulate RGB transport matrices for a scene.
+
+    Each channel has slightly different transport to model
+    wavelength-dependent material properties.
+
+    Args:
+        resolution: Grid resolution (NxN).
+        seed: Random seed for reproducibility.
+
+    Returns:
+        SpectralTransportMatrix with R, G, B channels.
+    """
+    n = resolution * resolution
+    rng = np.random.default_rng(seed)
+
+    # Generate a base transport matrix (diffuse scene)
+    base_T = rng.random((n, n)) * 0.5
+
+    spectral = SpectralTransportMatrix(resolution)
+
+    # Red channel: warm materials reflect more
+    T_r = base_T * rng.uniform(0.8, 1.2, base_T.shape)
+    # Green channel: neutral
+    T_g = base_T.copy()
+    # Blue channel: cool materials reflect more
+    T_b = base_T * rng.uniform(0.7, 1.1, base_T.shape)
+
+    spectral.add_channel('red', T_r)
+    spectral.add_channel('green', T_g)
+    spectral.add_channel('blue', T_b)
+
+    return spectral

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -1,0 +1,225 @@
+"""Tests for spectral transport matrix module.
+
+Validates wavelength-dependent transport matrix creation, forward/dual
+computation, and API endpoint integration.
+"""
+
+import numpy as np
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+
+from src.core.spectral import SpectralTransportMatrix, simulate_rgb_transport
+from src.api.main import app, state
+
+
+# ======================================================================
+# Unit tests for SpectralTransportMatrix
+# ======================================================================
+
+class TestSpectralTransportMatrix:
+    """Tests for the SpectralTransportMatrix class."""
+
+    @pytest.fixture
+    def spectral(self):
+        """Create a simple spectral transport with known matrices."""
+        stm = SpectralTransportMatrix(resolution=4)
+        rng = np.random.default_rng(42)
+        stm.add_channel('red', rng.random((16, 16)))
+        stm.add_channel('green', rng.random((16, 16)))
+        stm.add_channel('blue', rng.random((16, 16)))
+        return stm
+
+    def test_add_channel(self):
+        """Adding a channel stores a copy of the matrix."""
+        stm = SpectralTransportMatrix(resolution=2)
+        T = np.eye(4)
+        stm.add_channel('test', T)
+        assert 'test' in stm.channels
+        np.testing.assert_array_equal(stm.channels['test'], T)
+        # Verify it's a copy
+        T[0, 0] = 999
+        assert stm.channels['test'][0, 0] == 1.0
+
+    def test_get_state(self, spectral):
+        """get_state should return resolution, channel names, and shapes."""
+        state = spectral.get_state()
+        assert state['resolution'] == 4
+        assert set(state['channels']) == {'red', 'green', 'blue'}
+        for name in ['red', 'green', 'blue']:
+            assert state['shapes'][name] == [16, 16]
+
+    def test_compute_rgb_from_scene(self, spectral):
+        """Forward spectral computation should produce per-channel images."""
+        n = 16
+        pattern = np.ones(n)
+        reflectance = {
+            'red': np.ones(n) * 0.8,
+            'green': np.ones(n) * 0.5,
+            'blue': np.ones(n) * 0.3,
+        }
+        result = spectral.compute_rgb_from_scene(reflectance, pattern)
+        assert set(result.keys()) == {'red', 'green', 'blue'}
+        for name, img in result.items():
+            assert img.shape == (n,)
+            assert np.all(np.isfinite(img))
+
+    def test_compute_rgb_without_reflectance(self, spectral):
+        """If a channel has no reflectance entry, use T directly."""
+        n = 16
+        pattern = np.ones(n)
+        # Only provide red reflectance
+        reflectance = {'red': np.ones(n) * 0.5}
+        result = spectral.compute_rgb_from_scene(reflectance, pattern)
+        # green and blue should still work (using T @ pattern directly)
+        assert 'green' in result
+        assert 'blue' in result
+
+    def test_dual_image_spectral(self, spectral):
+        """Dual image for a channel should use T^T."""
+        n = 16
+        illumination = np.ones(n)
+        dual = spectral.dual_image_spectral('red', illumination)
+        assert dual.shape == (n,)
+        # Verify it equals T^T @ illumination
+        expected = spectral.channels['red'].T @ illumination
+        np.testing.assert_allclose(dual, expected)
+
+    def test_dual_image_unknown_channel(self, spectral):
+        """Requesting unknown channel should raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown channel"):
+            spectral.dual_image_spectral('infrared', np.ones(16))
+
+    def test_different_channels_produce_different_results(self, spectral):
+        """Different channels should give different dual images."""
+        illumination = np.ones(16)
+        dual_r = spectral.dual_image_spectral('red', illumination)
+        dual_g = spectral.dual_image_spectral('green', illumination)
+        assert not np.allclose(dual_r, dual_g)
+
+
+class TestSimulateRGBTransport:
+    """Tests for the simulate_rgb_transport convenience function."""
+
+    def test_creates_three_channels(self):
+        """Should create red, green, blue channels."""
+        stm = simulate_rgb_transport(resolution=4, seed=42)
+        assert set(stm.channels.keys()) == {'red', 'green', 'blue'}
+
+    def test_resolution_stored(self):
+        """Resolution should be stored correctly."""
+        stm = simulate_rgb_transport(resolution=8, seed=42)
+        assert stm.resolution == 8
+
+    def test_matrix_shapes(self):
+        """Transport matrices should be (n*n, n*n)."""
+        res = 4
+        stm = simulate_rgb_transport(resolution=res, seed=42)
+        n = res * res
+        for name, T in stm.channels.items():
+            assert T.shape == (n, n), f"Channel {name} has wrong shape"
+
+    def test_reproducibility(self):
+        """Same seed should produce identical results."""
+        stm1 = simulate_rgb_transport(resolution=4, seed=123)
+        stm2 = simulate_rgb_transport(resolution=4, seed=123)
+        for name in stm1.channels:
+            np.testing.assert_array_equal(stm1.channels[name], stm2.channels[name])
+
+    def test_channels_differ(self):
+        """R, G, B channels should not be identical."""
+        stm = simulate_rgb_transport(resolution=4, seed=42)
+        assert not np.allclose(stm.channels['red'], stm.channels['green'])
+        assert not np.allclose(stm.channels['green'], stm.channels['blue'])
+
+
+# ======================================================================
+# API endpoint tests
+# ======================================================================
+
+@pytest.fixture
+def transport():
+    return ASGITransport(app=app)
+
+
+@pytest_asyncio.fixture
+async def client(transport):
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_spectral_simulate_endpoint(client):
+    """POST /api/spectral-simulate should create spectral transport."""
+    response = await client.post(
+        "/api/spectral-simulate",
+        json={"resolution": 4, "seed": 42},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data['resolution'] == 4
+    assert set(data['channels']) == {'red', 'green', 'blue'}
+    assert 'sample_images' in data
+    assert set(data['sample_images'].keys()) == {'red', 'green', 'blue'}
+
+
+@pytest.mark.asyncio
+async def test_spectral_relight_endpoint(client):
+    """POST /api/spectral-relight should work after spectral-simulate."""
+    # First simulate
+    await client.post(
+        "/api/spectral-simulate",
+        json={"resolution": 4, "seed": 42},
+    )
+    # Then relight
+    response = await client.post(
+        "/api/spectral-relight",
+        json={"channel": "red", "pattern_type": "uniform"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data['channel'] == 'red'
+    assert data['resolution'] == 4
+    assert 'dual_image' in data
+
+
+@pytest.mark.asyncio
+async def test_spectral_relight_without_simulate(client):
+    """POST /api/spectral-relight before simulate should return 400."""
+    state.spectral = None
+    response = await client.post(
+        "/api/spectral-relight",
+        json={"channel": "red", "pattern_type": "uniform"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_spectral_relight_invalid_channel(client):
+    """POST /api/spectral-relight with invalid channel should return 400."""
+    await client.post(
+        "/api/spectral-simulate",
+        json={"resolution": 4, "seed": 42},
+    )
+    response = await client.post(
+        "/api/spectral-relight",
+        json={"channel": "infrared", "pattern_type": "uniform"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_spectral_relight_all_channels(client):
+    """All RGB channels should produce valid dual images."""
+    await client.post(
+        "/api/spectral-simulate",
+        json={"resolution": 4, "seed": 42},
+    )
+    for ch in ['red', 'green', 'blue']:
+        response = await client.post(
+            "/api/spectral-relight",
+            json={"channel": ch, "pattern_type": "spot"},
+        )
+        assert response.status_code == 200, f"Channel '{ch}' failed"
+        data = response.json()
+        assert len(data['dual_image']) == 16  # 4*4


### PR DESCRIPTION
## Summary
- SpectralTransportMatrix with per-channel (RGB) transport matrices
- Wavelength-dependent reflectance modulation
- Spectral relighting and per-channel dual photography
- POST /api/spectral-simulate + POST /api/spectral-relight
- 15 new tests

@codex Die spektrale Transportmatrix verwendet zufällige Skalierung (0.8-1.2) pro Kanal als Proxy für wellenlängenabhängige Reflexion. In der Realität kommen diese Werte aus BRDF-Messungen. Kennst du eine offene Datenbank gemessener BRDFs? 🇩🇪

**CODE REVIEW ONLY.**
🤖 Generated with [Claude Code](https://claude.ai/claude-code)