### PR TITLE
Feat: Architecture doc + pipeline SVG + README test-count fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ where **p_new** is an arbitrary virtual projector pattern. This enables real-tim
 
 ![System Architecture](docs/svg/architecture.svg)
 
+See [`docs/architecture.md`](docs/architecture.md) for tech-stack rationale, component responsibilities, and deployment models.
+
+### Processing Pipeline
+
+![Processing Pipeline](docs/svg/pipeline.svg)
+
+From UI input to primal / dual / relighted images in one round-trip: scene build → ray-cast occlusion → transport matrix **T** → SVD / primal / dual / relighting.
+
 ---
 
 ## Features
@@ -160,7 +168,7 @@ Open **http://127.0.0.1:8004** in your browser. Select a scene, click "Run Simul
 pytest tests/ -v
 ```
 
-70 tests covering core engine, simulation, and frontend callbacks.
+165 tests covering core engine, simulation, BRDF, spectral transport, calibration, analysis, REST API, and frontend callbacks.
 
 ---
 
@@ -184,13 +192,17 @@ src/
     └── assets/        # CSS styles
 
 docs/
+├── architecture.md             # System design, tech stack, deployment
 ├── 01_technical_reference.md   # Mathematical foundations and algorithms
 ├── 02_user_guide.md            # How to use the application
 ├── 03_history.md               # Development history and changelog
 ├── 04_references.md            # Bibliography and references
 ├── svg/                        # Diagrams
-│   ├── concept_dual_photography.svg
 │   ├── architecture.svg
+│   ├── concept_dual_photography.svg
+│   ├── helmholtz_reciprocity.svg
+│   ├── pipeline.svg
+│   ├── svd_interpretation.svg
 │   └── transport_matrix_theory.svg
 └── img/                        # Generated demo images
 ```
@@ -227,11 +239,13 @@ docs/
 
 See the [docs/](docs/) folder for:
 
+- [Architecture](docs/architecture.md) — System design, tech-stack rationale, component responsibilities, deployment models
 - [Technical Reference](docs/01_technical_reference.md) — Mathematical foundations, ray-casting algorithm, scene types
 - [User Guide](docs/02_user_guide.md) — Installation, usage, recommended experiments
 - [Development History](docs/03_history.md) — Changelog and architectural decisions
 - [References](docs/04_references.md) — Bibliography and related work
 - [Transport Matrix Theory (SVG)](docs/svg/transport_matrix_theory.svg) — Visual explanation of T, SVD, and applications
+- [Processing Pipeline (SVG)](docs/svg/pipeline.svg) — End-to-end flow from UI input to primal/dual/relit images
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,158 @@
+# Architecture — Dual Photography Lab
+
+System design, technology stack justification, component responsibilities, data flow, and deployment model for the Dual Photography Lab application.
+
+---
+
+## 1. High-Level Overview
+
+Dual Photography Lab is a **three-tier Python application** that makes the light transport matrix **T** the central data object of a small interactive lab. The three tiers mirror the README's *Frontend / API / Engine* architecture diagram (`docs/svg/architecture.svg`):
+
+| Tier | Responsibility | Key Modules |
+|------|----------------|-------------|
+| **Presentation (Dash UI)** | Interactive controls, figure rendering, REST façade for experiments | `src/frontend/app.py`, `src/api/main.py` |
+| **Domain Engine** | Transport matrix math, SVD, patterns, BRDF, spectral, calibration | `src/core/*` |
+| **Scene Simulation** | Virtual ray-cast renderer, scene primitives, pattern-to-image forward model | `src/simulation/scene.py`, `src/simulation/renderer.py` |
+| **Physical Capture (optional)** | Webcam + screen-as-projector acquisition with ambient subtraction | `src/capture/*` |
+
+See `docs/svg/architecture.svg` for the visual component diagram and `docs/svg/pipeline.svg` for the end-to-end processing pipeline.
+
+---
+
+## 2. Technology Stack — Why Each Piece
+
+| Layer | Choice | Why this, not something else |
+|-------|--------|-----------------------------|
+| Language | **Python 3.10+** | Scientific ecosystem (NumPy, SciPy), Felipe's team-wide standard, cross-platform without license fees (the original 2014 prototype was MATLAB-only). |
+| Numerical core | **NumPy + SciPy** | Vectorized ray-scene intersection, dense SVD via LAPACK, pseudoinverse solves. |
+| Web UI | **Dash + dash-bootstrap-components** | Pure-Python reactive UI — no separate JS frontend to maintain. Matches the "one repo, one stack" rule across Felipe's science portfolio. |
+| Visualization | **Plotly** | Interactive singular-value spectrum, matrix heatmaps, relighting previews — all rendered client-side. |
+| Imaging | **OpenCV + Pillow + scikit-image** | OpenCV for webcam capture / YUY2 conversion, Pillow for PNG encoding to base64 for the UI, scikit-image for auxiliary filters. |
+| REST API | **FastAPI-compatible surface via `src/api/main.py`** | Allows scripted experiments and headless CI runs without touching the UI. |
+| Tests | **pytest** (165 collected) | Fast, parametrized, integrates with ruff linting. |
+| Packaging | **pyproject.toml + setuptools** | Single source of truth for dependencies, version, console scripts. |
+| Desktop build | **PyInstaller** (`build.spec`, `Build_PyInstaller.ps1`) | One-file Windows executable for demos without Python install. |
+| Web deploy | **cPanel Passenger WSGI** (`passenger_wsgi.py`) | Matches Felipe's shared-host deployment target. |
+
+The stack deliberately avoids a framework split (e.g., React + FastAPI). Dash keeps the UI, callbacks, and scientific code in the same Python process, which removes a whole class of serialization / state-sync bugs while the lab is still evolving.
+
+---
+
+## 3. Component Responsibilities
+
+### 3.1 `src/core/` — The Scientific Engine
+
+- **`transport.py`** — `TransportMatrix`: holds `T` (dense NumPy array), provides `forward(p)`, `dual(c)`, `relight(p_new)`, `svd(rank)`, `save / load`. This is the single authoritative object representing a captured light transport.
+- **`patterns.py`** — Canonical, Hadamard, Bernoulli, and Gray-code pattern generators. Each returns an `(N, H, W)` stack.
+- **`dual.py`** — `DualPhotographer` orchestrator: wires patterns → capture/simulate → `TransportMatrix` → dual image.
+- **`brdf.py`** — Lambertian and Blinn-Phong BRDFs used by the simulator.
+- **`spectral.py`** — RGB (3-channel) transport matrices and per-channel relighting.
+- **`calibration.py`** — Gray-code projector-camera pixel correspondence and geometric calibration.
+
+### 3.2 `src/simulation/` — Virtual Lab
+
+- **`scene.py`** — `SceneObject`, `SyntheticScene`: pinhole camera/projector, ray-casting against planes/rectangles/spheres, shadow-ray occlusion, texture mapping.
+- **`renderer.py`** — `VirtualRenderer`: end-to-end `run_simulation(scene_type, …)` returning a `SimulationResult` (primal, dual, T, analysis metadata).
+
+### 3.3 `src/capture/` — Physical Acquisition
+
+- **`camera.py`** — `CameraCapture` (OpenCV webcam wrapper, YUY2 → RGB).
+- **`projector.py`** — `ScreenProjector` (secondary-monitor fullscreen pattern display).
+- **`acquisition.py`** — `AcquisitionPipeline` synchronizing projection and capture with ambient subtraction.
+
+### 3.4 `src/frontend/` — Dash Application
+
+- **`app.py`** — Controls (`dbc.Select` for scene type, resolution, SVD rank, camera/projector X, pattern type), figures, callbacks. Serves on port **8004**.
+- **`assets/`** — CSS.
+
+### 3.5 `src/api/` — REST Surface
+
+- **`main.py`** — 11 endpoints: `/api/health`, `/api/scenes`, `/api/simulate`, `/api/relight`, `/api/svd`, `/api/transport`, `/api/frequency`, `/api/spectral-simulate`, `/api/spectral-relight`, `/api/calibrate`, `/api/log`. Used by tests and external scripts.
+
+---
+
+## 4. Data Flow — One Simulation Round-Trip
+
+1. **UI event** — user picks a scene and clicks *Run Simulation* in the Dash frontend.
+2. **Callback** — `src/frontend/app.py` packages parameters and calls `VirtualRenderer.run_simulation(...)`.
+3. **Scene build** — `scene.py` instantiates primitives (box, wall, sphere, …) for the selected `SceneType`.
+4. **Ray cast** — for every (projector pixel, camera pixel) pair, a ray is cast and tested for occlusion; `T[i, j]` is filled with `albedo * cos_in * cos_out / r^2` when the path is unblocked.
+5. **TransportMatrix** — the dense `T` is wrapped in a `TransportMatrix` object.
+6. **SVD** — `transport.svd(rank)` runs `numpy.linalg.svd`, keeps the top-k singular values, exposes `effective_rank_90`, `effective_rank_99`, `condition_number`.
+7. **Primal & dual** — `c = T · 1` (uniform illumination) and `p_dual = T^T · 1` are computed.
+8. **Plotly figures** — arrays are converted to Plotly heatmaps and base64 PNGs, returned to the browser.
+9. **Relighting** — subsequent UI events reuse the cached `T` and compute `c_new = T · p_new` without re-rendering the scene.
+
+The same flow is exercised headlessly by the REST API and by the 165 pytest tests.
+
+---
+
+## 5. Testing Strategy
+
+| Suite | Scope |
+|-------|-------|
+| `tests/test_core.py` | Pattern generators, `TransportMatrix` ops, SVD, save/load |
+| `tests/test_simulation.py` | Every scene type, non-negativity of `T`, off-diagonal structure, primal ≠ dual |
+| `tests/test_brdf.py` | Lambertian and Blinn-Phong BRDF properties |
+| `tests/test_spectral.py` | 3-channel (RGB) spectral transport |
+| `tests/test_calibration.py` | Gray-code correspondence decoding |
+| `tests/test_analysis.py` | Condition number, energy-fraction ranks |
+| `tests/test_api.py` | Every REST endpoint returns a valid payload |
+| `tests/test_frontend.py` | Every Dash callback fires cleanly for every scene |
+
+Run: `pytest tests/ -v`. Target: **165 passing** on every commit to `main`.
+
+---
+
+## 6. Deployment Models
+
+### 6.1 Local Development (default)
+
+```bash
+pip install -e ".[dev]"
+python -m src.frontend.app
+# http://127.0.0.1:8004
+```
+
+### 6.2 Standalone Windows Executable
+
+```powershell
+./Build_PyInstaller.ps1
+# -> dist/dual-photography.exe
+```
+
+Uses `build.spec` with explicit hidden imports for Dash and OpenCV. Produces a single-file Windows binary suitable for demos on machines without Python.
+
+### 6.3 cPanel Shared Hosting (Passenger WSGI)
+
+- Entry point: `passenger_wsgi.py` (root of repo).
+- Passenger loads the Dash `app.server` (Flask under the hood).
+- Port is determined by the hosting layer (Passenger maps an incoming request to the WSGI callable — the hard-coded 8004 only applies to local dev runs).
+
+### 6.4 Headless / CI
+
+```bash
+pytest tests/ -v
+```
+
+No display server required — the simulation, API, and SVD layers have zero GUI dependencies.
+
+---
+
+## 7. Design Principles
+
+1. **One canonical object (`TransportMatrix`)** — every downstream operation (dual, relight, SVD, save/load, spectral) acts on this single class so that the physics stays in one file.
+2. **Simulation first, hardware optional** — the virtual renderer is the default path; `src/capture/` is fully separable and never imported by the frontend.
+3. **Deterministic tests** — scenes and patterns are seedable; `pytest` runs under 10 s end-to-end.
+4. **Manager-first README, developer-first `docs/`** — the README answers "why should I care?", this file answers "how is it built?".
+
+---
+
+## 8. See Also
+
+- [`docs/01_technical_reference.md`](01_technical_reference.md) — deep equations, ray-casting math, SVD interpretation
+- [`docs/02_user_guide.md`](02_user_guide.md) — running the app, recommended experiments
+- [`docs/03_history.md`](03_history.md) — version-by-version changelog
+- [`docs/04_references.md`](04_references.md) — academic bibliography
+- [`docs/svg/architecture.svg`](svg/architecture.svg) — visual component diagram
+- [`docs/svg/pipeline.svg`](svg/pipeline.svg) — processing pipeline flow

--- a/docs/svg/pipeline.svg
+++ b/docs/svg/pipeline.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <marker id="arrBlue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7aa2f7"/>
+    </marker>
+    <marker id="arrPurple" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#bb9af7"/>
+    </marker>
+    <marker id="arrGreen" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#9ece6a"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="560" fill="#0d1117" rx="12"/>
+
+  <!-- Title -->
+  <text x="450" y="34" text-anchor="middle" font-size="22" font-weight="bold" fill="#c0caf5">
+    Processing Pipeline — Dual Photography Lab
+  </text>
+  <text x="450" y="56" text-anchor="middle" font-size="12" fill="#9aa5ce">
+    From user input to primal / dual / relighted images
+  </text>
+
+  <!-- ================= Row 1: Input / Scene ================= -->
+  <!-- Step 1: UI Input -->
+  <rect x="40" y="90" width="180" height="90" rx="10" fill="#1f2335" stroke="#7aa2f7" stroke-width="2"/>
+  <text x="130" y="115" text-anchor="middle" font-size="13" font-weight="bold" fill="#7aa2f7">1. UI Input</text>
+  <text x="130" y="138" text-anchor="middle" font-size="11" fill="#c0caf5">scene, resolution,</text>
+  <text x="130" y="154" text-anchor="middle" font-size="11" fill="#c0caf5">SVD rank, cam/proj X,</text>
+  <text x="130" y="170" text-anchor="middle" font-size="11" fill="#c0caf5">pattern type</text>
+
+  <!-- Step 2: Scene Build -->
+  <rect x="260" y="90" width="180" height="90" rx="10" fill="#1f2335" stroke="#7aa2f7" stroke-width="2"/>
+  <text x="350" y="115" text-anchor="middle" font-size="13" font-weight="bold" fill="#7aa2f7">2. Scene Build</text>
+  <text x="350" y="138" text-anchor="middle" font-size="11" fill="#c0caf5">SyntheticScene:</text>
+  <text x="350" y="154" text-anchor="middle" font-size="11" fill="#c0caf5">planes, box, sphere,</text>
+  <text x="350" y="170" text-anchor="middle" font-size="11" fill="#c0caf5">textures, materials</text>
+
+  <!-- Step 3: Ray Cast -->
+  <rect x="480" y="90" width="180" height="90" rx="10" fill="#1f2335" stroke="#7aa2f7" stroke-width="2"/>
+  <text x="570" y="115" text-anchor="middle" font-size="13" font-weight="bold" fill="#7aa2f7">3. Ray Cast + Occlude</text>
+  <text x="570" y="138" text-anchor="middle" font-size="11" fill="#c0caf5">vectorized NumPy,</text>
+  <text x="570" y="154" text-anchor="middle" font-size="11" fill="#c0caf5">shadow rays,</text>
+  <text x="570" y="170" text-anchor="middle" font-size="11" fill="#c0caf5">cos·cos / r² · albedo</text>
+
+  <!-- Step 4: Build T -->
+  <rect x="700" y="90" width="170" height="90" rx="10" fill="#1f2335" stroke="#bb9af7" stroke-width="2"/>
+  <text x="785" y="115" text-anchor="middle" font-size="13" font-weight="bold" fill="#bb9af7">4. Transport Matrix</text>
+  <text x="785" y="138" text-anchor="middle" font-size="11" fill="#c0caf5">T (mn × pq),</text>
+  <text x="785" y="154" text-anchor="middle" font-size="11" fill="#c0caf5">normalized,</text>
+  <text x="785" y="170" text-anchor="middle" font-size="11" fill="#c0caf5">wrapped in class</text>
+
+  <!-- Arrows row 1 -->
+  <line x1="220" y1="135" x2="260" y2="135" stroke="#7aa2f7" stroke-width="2" marker-end="url(#arrBlue)"/>
+  <line x1="440" y1="135" x2="480" y2="135" stroke="#7aa2f7" stroke-width="2" marker-end="url(#arrBlue)"/>
+  <line x1="660" y1="135" x2="700" y2="135" stroke="#bb9af7" stroke-width="2" marker-end="url(#arrPurple)"/>
+
+  <!-- ================= Row 2: Analysis ================= -->
+  <!-- Step 5: SVD -->
+  <rect x="40" y="230" width="180" height="90" rx="10" fill="#1f2335" stroke="#bb9af7" stroke-width="2"/>
+  <text x="130" y="255" text-anchor="middle" font-size="13" font-weight="bold" fill="#bb9af7">5. SVD Decomp.</text>
+  <text x="130" y="278" text-anchor="middle" font-size="11" fill="#c0caf5">T = U · Σ · V^T,</text>
+  <text x="130" y="294" text-anchor="middle" font-size="11" fill="#c0caf5">rank-k truncation,</text>
+  <text x="130" y="310" text-anchor="middle" font-size="11" fill="#c0caf5">condition number</text>
+
+  <!-- Step 6: Primal -->
+  <rect x="260" y="230" width="180" height="90" rx="10" fill="#1f2335" stroke="#9ece6a" stroke-width="2"/>
+  <text x="350" y="255" text-anchor="middle" font-size="13" font-weight="bold" fill="#9ece6a">6. Primal Image</text>
+  <text x="350" y="278" text-anchor="middle" font-size="11" fill="#c0caf5">c = T · 1</text>
+  <text x="350" y="294" text-anchor="middle" font-size="11" fill="#c0caf5">(uniform projection,</text>
+  <text x="350" y="310" text-anchor="middle" font-size="11" fill="#c0caf5">camera view)</text>
+
+  <!-- Step 7: Dual -->
+  <rect x="480" y="230" width="180" height="90" rx="10" fill="#1f2335" stroke="#9ece6a" stroke-width="2"/>
+  <text x="570" y="255" text-anchor="middle" font-size="13" font-weight="bold" fill="#9ece6a">7. Dual Image</text>
+  <text x="570" y="278" text-anchor="middle" font-size="11" fill="#c0caf5">p_dual = T^T · 1</text>
+  <text x="570" y="294" text-anchor="middle" font-size="11" fill="#c0caf5">(Helmholtz reciprocity,</text>
+  <text x="570" y="310" text-anchor="middle" font-size="11" fill="#c0caf5">projector view)</text>
+
+  <!-- Step 8: Relight -->
+  <rect x="700" y="230" width="170" height="90" rx="10" fill="#1f2335" stroke="#9ece6a" stroke-width="2"/>
+  <text x="785" y="255" text-anchor="middle" font-size="13" font-weight="bold" fill="#9ece6a">8. Relighting</text>
+  <text x="785" y="278" text-anchor="middle" font-size="11" fill="#c0caf5">c_new = T · p_new</text>
+  <text x="785" y="294" text-anchor="middle" font-size="11" fill="#c0caf5">arbitrary patterns,</text>
+  <text x="785" y="310" text-anchor="middle" font-size="11" fill="#c0caf5">no re-capture</text>
+
+  <!-- Arrows down from T to SVD (curved) -->
+  <path d="M 785 180 Q 785 205 400 205 Q 130 205 130 230" fill="none" stroke="#bb9af7" stroke-width="2" stroke-dasharray="4,3" marker-end="url(#arrPurple)"/>
+  <text x="420" y="200" text-anchor="middle" font-size="10" fill="#9aa5ce">T feeds all analyses</text>
+
+  <!-- Arrows row 2 -->
+  <line x1="220" y1="275" x2="260" y2="275" stroke="#9ece6a" stroke-width="2" marker-end="url(#arrGreen)"/>
+  <line x1="440" y1="275" x2="480" y2="275" stroke="#9ece6a" stroke-width="2" marker-end="url(#arrGreen)"/>
+  <line x1="660" y1="275" x2="700" y2="275" stroke="#9ece6a" stroke-width="2" marker-end="url(#arrGreen)"/>
+
+  <!-- ================= Row 3: Output ================= -->
+  <!-- Step 9: Plotly -->
+  <rect x="150" y="370" width="260" height="90" rx="10" fill="#1f2335" stroke="#e0af68" stroke-width="2"/>
+  <text x="280" y="395" text-anchor="middle" font-size="13" font-weight="bold" fill="#e0af68">9. Plotly Figures + PNG</text>
+  <text x="280" y="418" text-anchor="middle" font-size="11" fill="#c0caf5">heatmaps, SVD spectrum,</text>
+  <text x="280" y="434" text-anchor="middle" font-size="11" fill="#c0caf5">primal / dual / relit</text>
+  <text x="280" y="450" text-anchor="middle" font-size="11" fill="#c0caf5">served to browser</text>
+
+  <!-- Step 10: REST API -->
+  <rect x="490" y="370" width="260" height="90" rx="10" fill="#1f2335" stroke="#e0af68" stroke-width="2"/>
+  <text x="620" y="395" text-anchor="middle" font-size="13" font-weight="bold" fill="#e0af68">10. REST API (alt path)</text>
+  <text x="620" y="418" text-anchor="middle" font-size="11" fill="#c0caf5">/api/simulate, /api/relight,</text>
+  <text x="620" y="434" text-anchor="middle" font-size="11" fill="#c0caf5">/api/svd, /api/spectral-*,</text>
+  <text x="620" y="450" text-anchor="middle" font-size="11" fill="#c0caf5">headless scripting</text>
+
+  <!-- Arrows row 3 -->
+  <path d="M 350 320 Q 350 345 280 345 Q 280 370 280 370" fill="none" stroke="#e0af68" stroke-width="2" marker-end="url(#arrBlue)"/>
+  <path d="M 570 320 Q 570 345 620 345 Q 620 370 620 370" fill="none" stroke="#e0af68" stroke-width="2" marker-end="url(#arrBlue)"/>
+
+  <!-- ================= Legend ================= -->
+  <rect x="40" y="490" width="820" height="50" rx="8" fill="#1a1b26" stroke="#414868" stroke-width="1"/>
+  <circle cx="70" cy="515" r="6" fill="#7aa2f7"/>
+  <text x="85" y="519" font-size="11" fill="#c0caf5">Input / Simulation</text>
+  <circle cx="230" cy="515" r="6" fill="#bb9af7"/>
+  <text x="245" y="519" font-size="11" fill="#c0caf5">Transport matrix core</text>
+  <circle cx="420" cy="515" r="6" fill="#9ece6a"/>
+  <text x="435" y="519" font-size="11" fill="#c0caf5">Imaging operations (c = T·p, p_dual = T^T·c)</text>
+  <circle cx="720" cy="515" r="6" fill="#e0af68"/>
+  <text x="735" y="519" font-size="11" fill="#c0caf5">Output / API</text>
+</svg>


### PR DESCRIPTION
Closes #21

## Summary
- Add `docs/architecture.md`: tech-stack rationale, per-module responsibilities, data flow, deployment models (local, PyInstaller, cPanel Passenger WSGI, headless CI).
- Add `docs/svg/pipeline.svg`: 10-step processing pipeline SVG (dark background, color-coded).
- Fix README test-count inconsistency (70 -> 165) and link the new architecture doc and pipeline SVG.

## Test plan
- [x] `pytest tests/ --collect-only -q` still reports 165 tests
- [x] All referenced paths verified on disk
- [x] `docs/svg/pipeline.svg` parses as valid XML
- [x] README Parts 1/2/3 order preserved

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>